### PR TITLE
feat(executeFetch): utilize composeFetch function

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ Thunk-provided `fetchClient` overrides `baseFetch` as the concerns of the
 environment are more important such as providing cookie support on the server or
 enforcing request timeouts.
 
+To retain the ability to apply additional fetch functionality with a thunk-provided
+`fetchClient` you may also extend the behavior by providing a `composeFetch`
+function in the configuration that returns a composed fetch function.
+
 ```javascript
 import { createStore, combineReducers, applyMiddleware } from 'redux';
 import { configureIguazuREST, resourcesReducer } from 'iguazu-rest';
@@ -113,6 +117,9 @@ configureIguazuREST({
 
   // Overriden by thunk.withExtraArgument below
   baseFetch: fetchWith6sTimeout,
+
+  // Restored functionality with composition
+  composeFetch: (customFetch) => composeFetchWith6sTimeout(customFetch),
 });
 
 /* Contrived custom fetch client */

--- a/src/actions/executeFetch.js
+++ b/src/actions/executeFetch.js
@@ -48,7 +48,12 @@ const actionTypeMethodMap = {
 async function getAsyncData({
   resource, id, opts, actionType, state, fetchClient,
 }) {
-  const { resources, defaultOpts, baseFetch } = config;
+  const {
+    resources,
+    defaultOpts,
+    baseFetch,
+    composeFetch,
+  } = config;
   const { url, opts: resourceOpts } = resources[resource].fetch(id, actionType, state);
 
   const fetchOpts = merge.all([
@@ -60,8 +65,9 @@ async function getAsyncData({
   const fetchUrl = buildFetchUrl({ url, id, opts: fetchOpts });
 
   const selectedFetchClient = fetchClient || baseFetch;
+  const composedFetchClient = composeFetch(selectedFetchClient);
 
-  const res = await selectedFetchClient(fetchUrl, fetchOpts);
+  const res = await composedFetchClient(fetchUrl, fetchOpts);
   const rawData = await extractDataFromResponse(res);
   const { transformData } = config.resources[resource];
   const data = transformData ? transformData(rawData, { id, opts, actionType }) : rawData;

--- a/src/config.js
+++ b/src/config.js
@@ -16,6 +16,7 @@
 
 const config = {
   baseFetch: fetch,
+  composeFetch: (fetch) => fetch,
   getToState: (state) => state.resources,
 };
 


### PR DESCRIPTION
Applying the newly added `composeFetch` function will allow consumers to extend the fetch abilities when using the thunk supplied `fetchClient`. By default the `composeFetch` function passes through the thunk supplied or base configured  `fetchClient` with no changes.