### PR TITLE
feat(errors): clarify messaging for collection fetch errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ To use the functions that operate on collections, your API and config needs to m
 
 * The URL specified on the `fetch` config should return the full collection when the `/:id` is omitted. 
 * The API must return an array of resource objects. If it returns an object (common in paged APIs), you can use the `transformData` config function to return the array field of the object instead.
-* Each object in the array must have a unique ID field, normally named `id`.  If it is not named `id`, then the field name must be set in the `idKey` prop on the resource config. 
+* Each object in the array must have a unique ID field, normally named `id`.  If it is not named `id`, then the field name must be set in the `idKey` prop on the resource config. Iguazu will throw an error on successful network responses if it cannot find a unique ID for each item in the array.
 
 ### Reducer
 ```javascript

--- a/__tests__/helpers/hash.spec.js
+++ b/__tests__/helpers/hash.spec.js
@@ -15,6 +15,7 @@
  */
 
 import { getResourceIdHash, getCollectionIdHash, getQueryHash } from '../../src/helpers/hash';
+import { ID_TYPE_ERROR } from '../../src/errors';
 
 describe('hash helpers', () => {
   describe('getResourceIdHash', () => {
@@ -39,22 +40,22 @@ describe('hash helpers', () => {
     describe('when type of id is invalid', () => {
       it('should throw an error when the id is null', () => {
         expect(() => getResourceIdHash(null)).toThrowError(
-          new Error('ID must be an object, number, or string')
+          new Error(ID_TYPE_ERROR)
         );
       });
       it('should throw an error when the id is undefined', () => {
         expect(() => getResourceIdHash(undefined)).toThrowError(
-          new Error('ID must be an object, number, or string')
+          new Error(ID_TYPE_ERROR)
         );
       });
       it('should throw an error when the id is a boolean', () => {
         expect(() => getResourceIdHash(false)).toThrowError(
-          new Error('ID must be an object, number, or string')
+          new Error(ID_TYPE_ERROR)
         );
       });
       it('should throw an error when the id is a function', () => {
         expect(() => getResourceIdHash(() => '42')).toThrowError(
-          new Error('ID must be an object, number, or string')
+          new Error(ID_TYPE_ERROR)
         );
       });
     });
@@ -79,12 +80,12 @@ describe('hash helpers', () => {
     describe('when type of id is invalid', () => {
       it('should throw an error when the id is a boolean and true', () => {
         expect(() => getCollectionIdHash(true)).toThrowError(
-          new Error('ID must be an object, number, or string')
+          new Error(ID_TYPE_ERROR)
         );
       });
       it('should throw an error when the id is a function', () => {
         expect(() => getCollectionIdHash(() => '42')).toThrowError(
-          new Error('ID must be an object, number, or string')
+          new Error(ID_TYPE_ERROR)
         );
       });
     });

--- a/src/errors.js
+++ b/src/errors.js
@@ -14,5 +14,5 @@
  * permissions and limitations under the License.
  */
 
-export const ID_TYPE_ERROR = 'ID must be an object, number, or string';
+export const ID_TYPE_ERROR = 'Collection response must be an array of objects containing a unique id key (either "id" by default, or a custom "idKey" of your choice). The ID must be an object, number, or string. For non-compliant API responses, you can transform the data using a custom "transformData" function.';
 export const ARRAY_RESPONSE_ERROR = 'Resource call must return an object, not an array';


### PR DESCRIPTION
This PR improves messaging around collection fetch errors.

It took **a lot** of head-scratching to figure out why I kept getting an error on `queryCollection()` calls. I kept trying every variation on ids I could send in my request, wondering why a successful network response would give me an Iguazu error.

It turned out the API I was consuming was sending back an array of objects that didn't have unique identifiers, and not that I was sending in a bad id with my Iguazu call.

The updated messaging should help future users diagnose more easily that the shape of their network _response_ is the problem, rather than the shape of their Iguazu _request_