### PR TITLE
fix(actions): added load and load collection to method overrides

### DIFF
--- a/__tests__/actions/executeFetch.spec.js
+++ b/__tests__/actions/executeFetch.spec.js
@@ -131,6 +131,92 @@ describe('executeFetch', () => {
       expect(data).toEqual([{ id: '123', name: 'joe' }]);
     });
 
+    it('should use specified REST method for LOAD in options if provided', async () => {
+      Object.assign(config, {
+        defaultOpts: { default: 'opt' },
+        resources: {
+          users: {
+            fetch: () => ({
+              url: 'http://api.domain.com/users/:id',
+              opts: {
+                resource: 'opt',
+              },
+            }),
+          },
+        },
+      });
+      fetch.mockResponseOnce(
+        JSON.stringify([{ id: '123', name: 'joe' }, { id: '456', name: 'josephine' }]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+      const thunk = executeFetch({
+        resource, id, opts: { ...opts, method: 'POST' }, actionType: 'LOAD',
+      });
+      const data = await thunk(dispatch, getState);
+      expect(data).toEqual([{ id: '123', name: 'joe' }, { id: '456', name: 'josephine' }]);
+      expect(fetch).toHaveBeenCalledWith(
+        'http://api.domain.com/users/123',
+        {
+          default: 'opt', method: 'POST', resource: 'opt', some: 'opt',
+        }
+      );
+      const promise = Promise.resolve(data);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: types.LOAD_STARTED,
+        resource,
+        id,
+        opts: {
+          ...opts,
+          method: 'POST',
+        },
+        promise,
+      });
+      expect(dispatch).toHaveBeenCalledWith('waitAndDispatchFinishedThunk');
+    });
+
+    it('should use specified REST method for LOAD_COLLECTION in options if provided', async () => {
+      Object.assign(config, {
+        defaultOpts: { default: 'opt' },
+        resources: {
+          users: {
+            fetch: () => ({
+              url: 'http://api.domain.com/users/:id',
+              opts: {
+                resource: 'opt',
+              },
+            }),
+          },
+        },
+      });
+      fetch.mockResponseOnce(
+        JSON.stringify([{ id: '123', name: 'joe' }, { id: '456', name: 'josephine' }]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      );
+      const thunk = executeFetch({
+        resource, id, opts: { ...opts, method: 'POST' }, actionType: 'LOAD_COLLECTION',
+      });
+      const data = await thunk(dispatch, getState);
+      expect(data).toEqual([{ id: '123', name: 'joe' }, { id: '456', name: 'josephine' }]);
+      expect(fetch).toHaveBeenCalledWith(
+        'http://api.domain.com/users/123',
+        {
+          default: 'opt', method: 'POST', resource: 'opt', some: 'opt',
+        }
+      );
+      const promise = Promise.resolve(data);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: types.LOAD_COLLECTION_STARTED,
+        resource,
+        id,
+        opts: {
+          ...opts,
+          method: 'POST',
+        },
+        promise,
+      });
+      expect(dispatch).toHaveBeenCalledWith('waitAndDispatchFinishedThunk');
+    });
+
     it('should use specified REST method for UPDATE_COLLECTION in options if provided', async () => {
       Object.assign(config, {
         defaultOpts: { default: 'opt' },
@@ -193,19 +279,19 @@ describe('executeFetch', () => {
         { status: 200, headers: { 'Content-Type': 'application/json' } }
       );
       const thunk = executeFetch({
-        resource, id, opts: { ...opts, method: 'POST' }, actionType: 'LOAD',
+        resource, id, opts: { ...opts, method: 'POST' }, actionType: 'UPDATE',
       });
       const data = await thunk(dispatch, getState);
       expect(data).toEqual([{ id: '123', name: 'joe' }, { id: '456', name: 'josephine' }]);
       expect(fetch).toHaveBeenCalledWith(
         'http://api.domain.com/users/123',
         {
-          default: 'opt', method: 'GET', resource: 'opt', some: 'opt',
+          default: 'opt', method: 'PUT', resource: 'opt', some: 'opt',
         }
       );
       const promise = Promise.resolve(data);
       expect(dispatch).toHaveBeenCalledWith({
-        type: types.LOAD_STARTED,
+        type: types.UPDATE_STARTED,
         resource,
         id,
         opts: {

--- a/src/actions/executeFetch.js
+++ b/src/actions/executeFetch.js
@@ -46,7 +46,7 @@ const actionTypeMethodMap = {
   PATCH: 'PATCH',
 };
 
-const overridableActionMethods = new Set(['UPDATE_COLLECTION']);
+const overridableActionMethods = new Set(['LOAD', 'LOAD_COLLECTION', 'UPDATE_COLLECTION']);
 
 async function getAsyncData({
   resource, id, opts, actionType, state, fetchClient,


### PR DESCRIPTION
Issue: 
Addressing a production issue where POST API is is no longer being invoked through the action queryResource. Because all of the LOAD and LOAD_COLLECTION calls are being defaulted to GET, the call will no longer fire.

Fix: 
Allow LOAD and LOAD_COLLECTION to be included in a set of overridable methods.

Reasoning: 
Load requests could be less bound by action type and can behave as a "GET" like, not strictly GET method. 
