### PR TITLE
feat(selector): rename and expose loaded selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,9 @@ These actions return a promise that resolves with the fetched data on successful
 
 ### Selectors
 #### `getResource({ resource, id })(state)`
+#### `getResourceIsLoaded({ resource, id })(state)`
 #### `getCollection({ resource, id, opts })(state)`
+#### `getCollectionIsLoaded({ resource, id, opts })(state)`
 
 ### Cleaning Actions
 #### `clearResource({ resource, id, opts })`

--- a/__tests__/actions/crud.spec.js
+++ b/__tests__/actions/crud.spec.js
@@ -25,11 +25,11 @@ import {
 } from '../../src/actions/crud';
 
 jest.mock('../../src/selectors', () => ({
-  resourceIsLoaded: jest.fn(),
+  getResourceIsLoaded: jest.fn(),
   getResource: jest.fn(() => () => {}),
   resourceIsLoading: jest.fn(),
   getResourceLoadPromise: jest.fn(),
-  collectionIsLoaded: jest.fn(),
+  getCollectionIsLoaded: jest.fn(),
   getCollection: jest.fn(() => () => []),
   collectionIsLoading: jest.fn(),
   getCollectionLoadPromise: jest.fn(),
@@ -54,7 +54,7 @@ describe('CRUD actions', () => {
   describe('loadResource', () => {
     it('should load a single resource if it is not loaded or loading', async () => {
       const thunk = loadResource({ resource, id, opts });
-      require('../../src/selectors').resourceIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
+      require('../../src/selectors').getResourceIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
       require('../../src/selectors').resourceIsLoading.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
       await thunk(dispatch, getState);
       expect(dispatch).toHaveBeenCalledWith(mockFetchPromise);
@@ -65,7 +65,7 @@ describe('CRUD actions', () => {
 
     it('should resolve with the cached resource if it is already loaded', async () => {
       const thunk = loadResource({ resource, id, opts });
-      require('../../src/selectors').resourceIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
+      require('../../src/selectors').getResourceIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
       await thunk(dispatch, getState);
       expect(dispatch).not.toHaveBeenCalled();
       expect(executeFetch).not.toHaveBeenCalled();
@@ -75,7 +75,7 @@ describe('CRUD actions', () => {
       const error = new Error('load error');
       try {
         const thunk = loadResource({ resource, id, opts });
-        require('../../src/selectors').resourceIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
+        require('../../src/selectors').getResourceIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
         require('../../src/selectors').getResource.mockImplementationOnce(() => () => error); // eslint-disable-line global-require
         await thunk(dispatch, getState);
       } catch (e) {
@@ -87,7 +87,7 @@ describe('CRUD actions', () => {
 
     it('should return with the loading promise if it is already in progress', async () => {
       const thunk = loadResource({ resource, id, opts });
-      require('../../src/selectors').resourceIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
+      require('../../src/selectors').getResourceIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
       require('../../src/selectors').resourceIsLoading.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
       require('../../src/selectors').getResourceLoadPromise.mockImplementationOnce(() => () => Promise.resolve()); // eslint-disable-line global-require
       await thunk(dispatch, getState);
@@ -99,7 +99,7 @@ describe('CRUD actions', () => {
       const thunk = loadResource({
         resource, id, opts, forceFetch: true,
       });
-      require('../../src/selectors').resourceIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
+      require('../../src/selectors').getResourceIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
       require('../../src/selectors').resourceIsLoading.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
       await thunk(dispatch, getState);
       expect(dispatch).toHaveBeenCalledWith(mockFetchPromise);
@@ -112,7 +112,7 @@ describe('CRUD actions', () => {
       const thunk = loadResource({
         resource, id, opts, forceFetch: true,
       });
-      require('../../src/selectors').resourceIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
+      require('../../src/selectors').getResourceIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
       require('../../src/selectors').resourceIsLoading.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
       await thunk(dispatch, getState);
       expect(dispatch).toHaveBeenCalledWith(mockFetchPromise);
@@ -125,7 +125,7 @@ describe('CRUD actions', () => {
   describe('loadCollection', () => {
     it('should load the collection if it is not loaded or loading', async () => {
       const thunk = loadCollection({ resource, opts });
-      require('../../src/selectors').collectionIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
+      require('../../src/selectors').getCollectionIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
       require('../../src/selectors').collectionIsLoading.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
       await thunk(dispatch, getState);
       expect(dispatch).toHaveBeenCalledWith(mockFetchPromise);
@@ -134,7 +134,7 @@ describe('CRUD actions', () => {
 
     it('should not refetch the collection if it is already loaded', async () => {
       const thunk = loadCollection({ resource, opts });
-      require('../../src/selectors').collectionIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
+      require('../../src/selectors').getCollectionIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
       await thunk(dispatch, getState);
       expect(dispatch).not.toHaveBeenCalled();
       expect(executeFetch).not.toHaveBeenCalled();
@@ -144,7 +144,7 @@ describe('CRUD actions', () => {
       const error = new Error('load error');
       try {
         const thunk = loadCollection({ resource, id, opts });
-        require('../../src/selectors').collectionIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
+        require('../../src/selectors').getCollectionIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
         require('../../src/selectors').getCollection.mockImplementationOnce(() => () => error); // eslint-disable-line global-require
         await thunk(dispatch, getState);
       } catch (e) {
@@ -156,7 +156,7 @@ describe('CRUD actions', () => {
 
     it('should not refetch the resource if a fetch is already in progress', async () => {
       const thunk = loadCollection({ resource, opts });
-      require('../../src/selectors').collectionIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
+      require('../../src/selectors').getCollectionIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
       require('../../src/selectors').collectionIsLoading.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
       require('../../src/selectors').getCollectionLoadPromise.mockImplementationOnce(() => () => Promise.resolve()); // eslint-disable-line global-require
       await thunk(dispatch, getState);
@@ -166,7 +166,7 @@ describe('CRUD actions', () => {
 
     it('should load the collection if the collection is loaded, but forceFetch is specified', async () => {
       const thunk = loadCollection({ resource, opts, forceFetch: true });
-      require('../../src/selectors').collectionIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
+      require('../../src/selectors').getCollectionIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
       require('../../src/selectors').collectionIsLoading.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
       await thunk(dispatch, getState);
       expect(dispatch).toHaveBeenCalledWith(mockFetchPromise);
@@ -177,7 +177,7 @@ describe('CRUD actions', () => {
       const thunk = loadCollection({
         resource, id, opts, forceFetch: true,
       });
-      require('../../src/selectors').collectionIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
+      require('../../src/selectors').getCollectionIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
       require('../../src/selectors').collectionIsLoading.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
       await thunk(dispatch, getState);
       expect(dispatch).toHaveBeenCalledWith(mockFetchPromise);

--- a/__tests__/actions/query.spec.js
+++ b/__tests__/actions/query.spec.js
@@ -25,8 +25,8 @@ jest.mock('../../src/actions/crud', () => ({
 jest.mock('../../src/selectors', () => ({
   getResource: jest.fn(() => () => 'resource'),
   getCollection: jest.fn(() => () => 'collection'),
-  resourceIsLoaded: jest.fn(),
-  collectionIsLoaded: jest.fn(),
+  getResourceIsLoaded: jest.fn(),
+  getCollectionIsLoaded: jest.fn(),
 }));
 
 jest.mock('../../src/actions/asyncSideEffects', () => ({
@@ -47,7 +47,7 @@ describe('iguazu query actions', () => {
 
   describe('queryResource', () => {
     it('should return a loading response if the resource is loading', () => {
-      require('../../src/selectors').resourceIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
+      require('../../src/selectors').getResourceIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
       const thunk = queryResource({ resource, id, opts });
       const loadResponse = thunk(dispatch, getState);
       expect(loadResponse.data).toEqual('resource');
@@ -57,7 +57,7 @@ describe('iguazu query actions', () => {
     });
 
     it('should return a loaded response if the resource is loaded', () => {
-      require('../../src/selectors').resourceIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
+      require('../../src/selectors').getResourceIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
       const thunk = queryResource({ resource, id, opts });
       const loadResponse = thunk(dispatch, getState);
       expect(loadResponse.data).toEqual('resource');
@@ -67,7 +67,7 @@ describe('iguazu query actions', () => {
     });
 
     it('should return a loading response if the resource is loaded, but forceFetch is specified', () => {
-      require('../../src/selectors').resourceIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
+      require('../../src/selectors').getResourceIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
       const thunk = queryResource({
         resource, id, opts, forceFetch: true,
       });
@@ -79,7 +79,7 @@ describe('iguazu query actions', () => {
     });
 
     it('should indicate an error occured if applicable', () => {
-      require('../../src/selectors').resourceIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
+      require('../../src/selectors').getResourceIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
       require('../../src/selectors').getResource.mockImplementationOnce(() => () => loadError); // eslint-disable-line global-require
       const thunk = queryResource({ resource, id, opts });
       const loadResponse = thunk(dispatch, getState);
@@ -91,7 +91,7 @@ describe('iguazu query actions', () => {
       const { handleQueryPromiseRejection } = require('../../src/actions/asyncSideEffects'); // eslint-disable-line global-require
       let promise;
       try {
-        require('../../src/selectors').resourceIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
+        require('../../src/selectors').getResourceIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
         require('../../src/actions/crud').loadResource.mockImplementationOnce(() => Promise.reject(new Error('async error'))); // eslint-disable-line global-require
         const thunk = queryResource({ resource, id, opts });
         const loadResponse = thunk(dispatch, getState);
@@ -106,7 +106,7 @@ describe('iguazu query actions', () => {
 
   describe('queryCollection', () => {
     it('should return a loading response if the collection is loading', () => {
-      require('../../src/selectors').collectionIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
+      require('../../src/selectors').getCollectionIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
       const thunk = queryCollection({ resource, id, opts });
       const loadResponse = thunk(dispatch, getState);
       expect(loadResponse.data).toEqual('collection');
@@ -115,7 +115,7 @@ describe('iguazu query actions', () => {
     });
 
     it('should return a loaded response if the collection is loaded', () => {
-      require('../../src/selectors').collectionIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
+      require('../../src/selectors').getCollectionIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
       const thunk = queryCollection({ resource, id, opts });
       const loadResponse = thunk(dispatch, getState);
       expect(loadResponse.data).toEqual('collection');
@@ -124,7 +124,7 @@ describe('iguazu query actions', () => {
     });
 
     it('should return a loading response if the collection is loaded, but forceFetch is specified', () => {
-      require('../../src/selectors').collectionIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
+      require('../../src/selectors').getCollectionIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
       const thunk = queryCollection({
         resource, id, opts, forceFetch: true,
       });
@@ -135,7 +135,7 @@ describe('iguazu query actions', () => {
     });
 
     it('should indicate an error occured if applicable', () => {
-      require('../../src/selectors').collectionIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
+      require('../../src/selectors').getCollectionIsLoaded.mockImplementationOnce(() => () => true); // eslint-disable-line global-require
       require('../../src/selectors').getCollection.mockImplementationOnce(() => () => loadError); // eslint-disable-line global-require
       const thunk = queryCollection({ resource, id, opts });
       const loadResponse = thunk(dispatch, getState);
@@ -147,7 +147,7 @@ describe('iguazu query actions', () => {
       const { handleQueryPromiseRejection } = require('../../src/actions/asyncSideEffects'); // eslint-disable-line global-require
       let promise;
       try {
-        require('../../src/selectors').collectionIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
+        require('../../src/selectors').getCollectionIsLoaded.mockImplementationOnce(() => () => false); // eslint-disable-line global-require
         require('../../src/actions/crud').loadCollection.mockImplementationOnce(() => Promise.reject(new Error('async error'))); // eslint-disable-line global-require
         const thunk = queryCollection({ resource, id, opts });
         const loadResponse = thunk(dispatch, getState);

--- a/__tests__/selectors.spec.js
+++ b/__tests__/selectors.spec.js
@@ -24,11 +24,11 @@ import {
 import { configureIguazuREST } from '../src/config';
 
 import {
-  resourceIsLoaded,
+  getResourceIsLoaded,
   getResource,
   resourceIsLoading,
   getResourceLoadPromise,
-  collectionIsLoaded,
+  getCollectionIsLoaded,
   getCollection,
   collectionIsLoading,
   getCollectionLoadPromise,
@@ -43,7 +43,7 @@ describe('selectors', () => {
     configureIguazuREST({ getToState: (state) => state.deep.resources });
   });
 
-  describe('resourceIsLoaded', () => {
+  describe('getResourceIsLoaded', () => {
     it('should return true if the resource is loaded', () => {
       const state = {
         deep: {
@@ -52,7 +52,7 @@ describe('selectors', () => {
           }),
         },
       };
-      expect(resourceIsLoaded({ resource, id })(state)).toBe(true);
+      expect(getResourceIsLoaded({ resource, id })(state)).toBe(true);
     });
 
     it('should return false if the resource is not loaded', () => {
@@ -63,7 +63,7 @@ describe('selectors', () => {
           }),
         },
       };
-      expect(resourceIsLoaded({ resource, id })(state)).toBe(false);
+      expect(getResourceIsLoaded({ resource, id })(state)).toBe(false);
     });
   });
 
@@ -138,7 +138,7 @@ describe('selectors', () => {
           }),
         },
       };
-      expect(resourceIsLoaded({ resource, id })(state)).toBe(true);
+      expect(getResourceIsLoaded({ resource, id })(state)).toBe(true);
     });
 
     it('should return false if the resource is not loading', () => {
@@ -167,7 +167,7 @@ describe('selectors', () => {
     });
   });
 
-  describe('collectionIsLoaded', () => {
+  describe('getCollectionIsLoaded', () => {
     it('should return true if the collection is loaded', () => {
       const collectionIdHash = getCollectionIdHash();
       const queryHash = getQueryHash();
@@ -178,7 +178,7 @@ describe('selectors', () => {
           }),
         },
       };
-      expect(collectionIsLoaded({ resource })(state)).toBe(true);
+      expect(getCollectionIsLoaded({ resource })(state)).toBe(true);
     });
 
     it('should return true if the collection is loaded with error', () => {
@@ -200,7 +200,7 @@ describe('selectors', () => {
           }),
         },
       };
-      expect(collectionIsLoaded({ resource })(state)).toBe(true);
+      expect(getCollectionIsLoaded({ resource })(state)).toBe(true);
     });
 
     it('should return false if the collection is not loaded', () => {
@@ -211,7 +211,7 @@ describe('selectors', () => {
           }),
         },
       };
-      expect(collectionIsLoaded({ resource })(state)).toBe(false);
+      expect(getCollectionIsLoaded({ resource })(state)).toBe(false);
     });
   });
 

--- a/src/actions/crud.js
+++ b/src/actions/crud.js
@@ -15,11 +15,11 @@
  */
 
 import {
-  resourceIsLoaded,
+  getResourceIsLoaded,
   getResource,
   resourceIsLoading,
   getResourceLoadPromise,
-  collectionIsLoaded,
+  getCollectionIsLoaded,
   getCollection,
   collectionIsLoading,
   getCollectionLoadPromise,
@@ -32,7 +32,7 @@ export function loadResource({
   return (dispatch, getState) => {
     const state = getState();
     let promise;
-    if (resourceIsLoaded({ resource, id })(state) && !forceFetch) {
+    if (getResourceIsLoaded({ resource, id })(state) && !forceFetch) {
       const data = getResource({ resource, id })(state);
       promise = data instanceof Error ? Promise.reject(data) : Promise.resolve(data);
     } else if (resourceIsLoading({ resource, id })(state) && !forceFetch) {
@@ -53,7 +53,7 @@ export function loadCollection({
   return (dispatch, getState) => {
     const state = getState();
     let promise;
-    if (collectionIsLoaded({ resource, id, opts })(state) && !forceFetch) {
+    if (getCollectionIsLoaded({ resource, id, opts })(state) && !forceFetch) {
       const data = getCollection({ resource, id, opts })(state);
       promise = data instanceof Error ? Promise.reject(data) : Promise.resolve(data);
     } else if (collectionIsLoading({ resource, id, opts })(state) && !forceFetch) {

--- a/src/actions/query.js
+++ b/src/actions/query.js
@@ -17,8 +17,8 @@
 import {
   getResource,
   getCollection,
-  resourceIsLoaded,
-  collectionIsLoaded,
+  getResourceIsLoaded,
+  getCollectionIsLoaded,
 } from '../selectors';
 import {
   loadResource,
@@ -34,7 +34,7 @@ export function queryResource({
   return (dispatch, getState) => {
     const state = getState();
     const data = getResource({ resource, id, opts })(state);
-    const status = resourceIsLoaded({ resource, id, opts })(state) && !forceFetch ? 'complete' : 'loading';
+    const status = getResourceIsLoaded({ resource, id, opts })(state) && !forceFetch ? 'complete' : 'loading';
     const error = data instanceof Error && data;
     const promise = dispatch(loadResource({
       resource, id, opts, forceFetch,
@@ -53,7 +53,7 @@ export function queryCollection({
   return (dispatch, getState) => {
     const state = getState();
     const data = getCollection({ resource, id, opts })(state);
-    const status = collectionIsLoaded({ resource, id, opts })(state) && !forceFetch ? 'complete' : 'loading';
+    const status = getCollectionIsLoaded({ resource, id, opts })(state) && !forceFetch ? 'complete' : 'loading';
     const error = data instanceof Error && data;
     const promise = dispatch(loadCollection({
       resource, id, opts, forceFetch,

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,9 @@ import {
 
 import {
   getResource,
+  getResourceIsLoaded,
   getCollection,
+  getCollectionIsLoaded,
 } from './selectors';
 
 import {
@@ -55,7 +57,9 @@ export {
   queryResource,
   queryCollection,
   getResource,
+  getResourceIsLoaded,
   getCollection,
+  getCollectionIsLoaded,
   clearResource,
   clearCollection,
   resourcesReducer,

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -23,7 +23,7 @@ import {
   getQueryHash,
 } from './helpers/hash';
 
-export function resourceIsLoaded({ resource, id }) {
+export function getResourceIsLoaded({ resource, id }) {
   return (state) => {
     const resourceState = config.getToState(state).get(resource, iMap());
     const idHash = getResourceIdHash(id);
@@ -50,7 +50,7 @@ export function getResourceLoadPromise({ resource, id }) {
   return (state) => config.getToState(state).getIn([resource, 'loading', getResourceIdHash(id)]);
 }
 
-export function collectionIsLoaded({ resource, id, opts }) {
+export function getCollectionIsLoaded({ resource, id, opts }) {
   return (state) => {
     const idHash = getCollectionIdHash(id);
     const queryHash = getQueryHash(opts);


### PR DESCRIPTION
Expose the "loaded" selectors for resources and collections under modified names that match the current API.

## Motivation and Context
This is done, primarily, to make it possible check for data to be loaded within collections as `getCollection` will always return an empty array regardless of it being requested or not. Added in additional for resources for parity.

## How Has This Been Tested?
Unit testing, then locally packing the repo and integrating into another library.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (adding or updating documentation)
- [ ] Dependency update

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] My changes are in sync with the code style of this project.
- [ ] There aren't any other open Pull Requests for the same issue/update.
- [ ] These changes should be applied to a maintenance branch.
- [ ] I have added the Apache 2.0 license header to any new files created.

## What is the Impact to Developers Using Iguazu-Rest?
None, forward change that only adds functionality.
